### PR TITLE
Add Perl6

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -25,6 +25,7 @@
   "Ocaml",
   "Pascal",
   "Perl",
+  "Perl 6",
   "PHP",
   "Python",
   "Ruby",


### PR DESCRIPTION
Not sure if it should be "Perl_6", "Perl 6", or "Perl6" though. Depending on where you scrape this info from.